### PR TITLE
add transaction utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 stack-*.lock
 stack.*.lock
 .direnv
+.envrc

--- a/persistent-sql-lifted/CHANGELOG.md
+++ b/persistent-sql-lifted/CHANGELOG.md
@@ -1,9 +1,14 @@
-## [_Unreleased_](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.1.0.0...main)
+## [_Unreleased_](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.1.1.0...main)
 
-## [v0.0.0.1](https://github.com/freckle/freckle-app/compare/persistent-sql-lifted-v0.0.0.0...persistent-sql-lifted-v0.1.0.0)
+## [v0.1.1.0](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.1.0.0...persistent-sql-lifted-v0.1.1.0)
 
-Major expansion, adding query runners for Persistent and Esqueleto.
+New:
 
-## [v0.0.0.0](https://github.com/freckle/freckle-app/tree/persistent-sql-lifted-v0.0.0.0/persistent-sql-lifted)
+- `transactionSave`
+- `transactionSaveWithIsolation`
+- `transactionUndo`
+- `transactionUndoWithIsolation`
+
+## [v0.1.0.0](https://github.com/freckle/persistent-sql-lifted/tree/persistent-sql-lifted-v0.0.0.0/persistent-sql-lifted)
 
 First release, sprouted from `freckle-app-1.20.3.0`.

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted.hs
@@ -85,6 +85,12 @@ module Database.Persist.Sql.Lifted
   , deleteWhere
   , deleteCount
 
+    -- * Transactions
+  , transactionSave
+  , transactionSaveWithIsolation
+  , transactionUndo
+  , transactionUndoWithIsolation
+
     -- * Rendering queries to text
   , renderQueryDelete
   , renderQueryInsertInto

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Persistent.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Persistent.hs
@@ -37,6 +37,10 @@ module Database.Persist.Sql.Lifted.Persistent
   , selectKeys
   , selectKeysList
   , selectList
+  , transactionSave
+  , transactionSaveWithIsolation
+  , transactionUndo
+  , transactionUndoWithIsolation
   , update
   , updateGet
   , updateWhere
@@ -66,6 +70,8 @@ import Database.Persist
   )
 import Database.Persist.Class qualified as P
 import Database.Persist.Class.PersistEntity (SafeToInsert)
+import Database.Persist.Sql (IsolationLevel)
+import Database.Persist.Sql qualified as P
 import Database.Persist.Sql.Lifted.Core (MonadSqlBackend, SqlBackend, liftSql)
 import GHC.Stack (HasCallStack)
 
@@ -556,6 +562,32 @@ selectList
   -> m [Entity a]
   -- ^ Entities corresponding to the filters and options provided
 selectList fs os = liftSql $ P.selectList fs os
+
+-- | Commit the current transaction and begin a new one
+transactionSave :: forall m. (MonadSqlBackend m, HasCallStack) => m ()
+transactionSave = liftSql P.transactionSave
+
+-- | Commit the current transaction and begin a new one
+transactionSaveWithIsolation
+  :: forall m
+   . (MonadSqlBackend m, HasCallStack)
+  => IsolationLevel
+  -- ^ Isolation level
+  -> m ()
+transactionSaveWithIsolation il = liftSql $ transactionSaveWithIsolation il
+
+-- | Roll back the current transaction and begin a new one
+transactionUndo :: forall m. (MonadSqlBackend m, HasCallStack) => m ()
+transactionUndo = liftSql transactionUndo
+
+-- | Roll back the current transaction and begin a new one
+transactionUndoWithIsolation
+  :: forall m
+   . (MonadSqlBackend m, HasCallStack)
+  => IsolationLevel
+  -- ^ Isolation level
+  -> m ()
+transactionUndoWithIsolation il = liftSql $ transactionUndoWithIsolation il
 
 -- | Update individual fields on a specific record
 update

--- a/persistent-sql-lifted/package.yaml
+++ b/persistent-sql-lifted/package.yaml
@@ -1,5 +1,5 @@
 name: persistent-sql-lifted
-version: 0.1.0.0
+version: 0.1.1.0
 
 maintainer: Freckle Education
 category: Database

--- a/persistent-sql-lifted/persistent-sql-lifted.cabal
+++ b/persistent-sql-lifted/persistent-sql-lifted.cabal
@@ -5,10 +5,10 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           persistent-sql-lifted
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:       Monad classes for running queries with Persistent and Esqueleto
 description:    This package introduces two classes: MonadSqlBackend for monadic contexts in
-                which a SqlBackend is available, and MonadSqlBackend for contexts in which we
+                which a SqlBackend is available, and MonadSqlTx for contexts in which we
                 can execute a SQL transaction.
                 .
                 Additionally, this package provides variants of query-running utilities from


### PR DESCRIPTION
I had missed these in the initial release because they come from a different module than most of Persistent ([Database.Persist.Sql](https://hackage.haskell.org/package/persistent-2.14.6.3/docs/Database-Persist-Sql.html)).

This also includes correction to some mistakes in the change log.