### PR TITLE
add many new reexport modules

### DIFF
--- a/persistent-sql-lifted/CHANGELOG.md
+++ b/persistent-sql-lifted/CHANGELOG.md
@@ -1,4 +1,38 @@
-## [_Unreleased_](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.1.1.0...main)
+## [_Unreleased_](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.2.0.0...main)
+
+## [v0.2.0.0](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.1.1.0...persistent-sql-lifted-v0.2.0.0)
+
+New modules:
+
+- `Database.Persist.Sql.Lifted.Expression`
+- `Database.Persist.Sql.Lifted.Expression.Bool`
+- `Database.Persist.Sql.Lifted.Expression.Case`
+- `Database.Persist.Sql.Lifted.Expression.Comparison`
+- `Database.Persist.Sql.Lifted.Expression.Constant`
+- `Database.Persist.Sql.Lifted.Expression.Count`
+- `Database.Persist.Sql.Lifted.Expression.Exists`
+- `Database.Persist.Sql.Lifted.Expression.Insert`
+- `Database.Persist.Sql.Lifted.Expression.Key`
+- `Database.Persist.Sql.Lifted.Expression.List`
+- `Database.Persist.Sql.Lifted.Expression.Maybe`
+- `Database.Persist.Sql.Lifted.Expression.Number`
+- `Database.Persist.Sql.Lifted.Expression.OrderBy`
+- `Database.Persist.Sql.Lifted.Expression.Projection`
+- `Database.Persist.Sql.Lifted.Expression.String`
+- `Database.Persist.Sql.Lifted.Expression.SubSelect`
+- `Database.Persist.Sql.Lifted.Expression.Table`
+- `Database.Persist.Sql.Lifted.Expression.Type`
+- `Database.Persist.Sql.Lifted.Expression.Update`
+- `Database.Persist.Sql.Lifted.Filter`
+- `Database.Persist.Sql.Lifted.From`
+- `Database.Persist.Sql.Lifted.Query`
+- `Database.Persist.Sql.Lifted.Query.Aggregate`
+- `Database.Persist.Sql.Lifted.Query.CommonTableExpressions`
+- `Database.Persist.Sql.Lifted.Query.Core`
+- `Database.Persist.Sql.Lifted.Query.Locking`
+- `Database.Persist.Sql.Lifted.Query.SetOperations`
+- `Database.Persist.Sql.Lifted.Query.Update`
+- `Database.Persist.Sql.Lifted.Update`
 
 ## [v0.1.1.0](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.1.0.0...persistent-sql-lifted-v0.1.1.0)
 

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression.hs
@@ -1,0 +1,138 @@
+module Database.Persist.Sql.Lifted.Expression
+  ( -- * Type
+    SqlExpr
+
+    -- * Constant
+  , val
+
+    -- * Bool
+  , not_
+  , (&&.)
+  , (||.)
+
+    -- * Case
+  , case_
+  , when_
+  , then_
+  , else_
+
+    -- * Comparison
+  , (==.)
+  , (!=.)
+  , (>=.)
+  , (>.)
+  , (<=.)
+  , (<.)
+  , between
+
+    -- * Count
+  , count
+  , countRows
+  , countDistinct
+
+    -- * Exists
+  , exists
+  , notExists
+
+    -- * Insert
+  , (<#)
+  , (<&>)
+
+    -- * Key
+  , toBaseId
+  , ToBaseId (..)
+
+    -- * List
+  , in_
+  , notIn
+  , subList_select
+  , valList
+  , justList
+
+    -- * Maybe
+  , isNothing
+  , isNothing_
+  , just
+  , nothing
+  , joinV
+  , coalesce
+  , coalesceDefault
+
+    -- * Number
+  , (+.)
+  , (-.)
+  , (/.)
+  , (*.)
+  , round_
+  , ceiling_
+  , floor_
+  , min_
+  , max_
+  , sum_
+  , avg_
+  , castNum
+  , castNumM
+
+    -- * OrderBy
+  , asc
+  , desc
+  , rand
+
+    -- * Projection
+  , (^.)
+  , (?.)
+
+    -- * String
+  , lower_
+  , upper_
+  , trim_
+  , ltrim_
+  , rtrim_
+  , length_
+  , left_
+  , right_
+  , like
+  , ilike
+  , (%)
+  , concat_
+  , (++.)
+  , castString
+
+    -- * SubSelect
+  , subSelect
+  , subSelectMaybe
+  , subSelectCount
+  , subSelectForeign
+  , subSelectList
+  , subSelectUnsafe
+
+    -- * Table
+  , getTable
+  , getTableMaybe
+
+    -- * Update
+  , (=.)
+  , (+=.)
+  , (-=.)
+  , (*=.)
+  , (/=.)
+  ) where
+
+import Database.Persist.Sql.Lifted.Expression.Bool
+import Database.Persist.Sql.Lifted.Expression.Case
+import Database.Persist.Sql.Lifted.Expression.Comparison
+import Database.Persist.Sql.Lifted.Expression.Constant
+import Database.Persist.Sql.Lifted.Expression.Count
+import Database.Persist.Sql.Lifted.Expression.Exists
+import Database.Persist.Sql.Lifted.Expression.Insert
+import Database.Persist.Sql.Lifted.Expression.Key
+import Database.Persist.Sql.Lifted.Expression.List
+import Database.Persist.Sql.Lifted.Expression.Maybe
+import Database.Persist.Sql.Lifted.Expression.Number
+import Database.Persist.Sql.Lifted.Expression.OrderBy
+import Database.Persist.Sql.Lifted.Expression.Projection
+import Database.Persist.Sql.Lifted.Expression.String
+import Database.Persist.Sql.Lifted.Expression.SubSelect
+import Database.Persist.Sql.Lifted.Expression.Table
+import Database.Persist.Sql.Lifted.Expression.Type
+import Database.Persist.Sql.Lifted.Expression.Update

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Bool.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Bool.hs
@@ -1,0 +1,7 @@
+module Database.Persist.Sql.Lifted.Expression.Bool
+  ( not_
+  , (&&.)
+  , (||.)
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Case.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Case.hs
@@ -1,0 +1,8 @@
+module Database.Persist.Sql.Lifted.Expression.Case
+  ( case_
+  , when_
+  , then_
+  , else_
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Comparison.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Comparison.hs
@@ -1,0 +1,14 @@
+module Database.Persist.Sql.Lifted.Expression.Comparison
+  ( -- * Equality
+    (==.)
+  , (!=.)
+
+    -- * Less & greater
+  , (>=.)
+  , (>.)
+  , (<=.)
+  , (<.)
+  , between
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Constant.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Constant.hs
@@ -1,0 +1,5 @@
+module Database.Persist.Sql.Lifted.Expression.Constant
+  ( val
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Count.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Count.hs
@@ -1,0 +1,7 @@
+module Database.Persist.Sql.Lifted.Expression.Count
+  ( count
+  , countRows
+  , countDistinct
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Exists.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Exists.hs
@@ -1,0 +1,6 @@
+module Database.Persist.Sql.Lifted.Expression.Exists
+  ( exists
+  , notExists
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Insert.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Insert.hs
@@ -1,0 +1,6 @@
+module Database.Persist.Sql.Lifted.Expression.Insert
+  ( (<#)
+  , (<&>)
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Key.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Key.hs
@@ -1,0 +1,6 @@
+module Database.Persist.Sql.Lifted.Expression.Key
+  ( toBaseId
+  , ToBaseId (..)
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/List.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/List.hs
@@ -1,0 +1,9 @@
+module Database.Persist.Sql.Lifted.Expression.List
+  ( in_
+  , notIn
+  , subList_select
+  , valList
+  , justList
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Maybe.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Maybe.hs
@@ -1,0 +1,11 @@
+module Database.Persist.Sql.Lifted.Expression.Maybe
+  ( isNothing
+  , isNothing_
+  , just
+  , nothing
+  , joinV
+  , coalesce
+  , coalesceDefault
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Number.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Number.hs
@@ -1,0 +1,17 @@
+module Database.Persist.Sql.Lifted.Expression.Number
+  ( (+.)
+  , (-.)
+  , (/.)
+  , (*.)
+  , round_
+  , ceiling_
+  , floor_
+  , min_
+  , max_
+  , sum_
+  , avg_
+  , castNum
+  , castNumM
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/OrderBy.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/OrderBy.hs
@@ -1,0 +1,7 @@
+module Database.Persist.Sql.Lifted.Expression.OrderBy
+  ( asc
+  , desc
+  , rand
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Projection.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Projection.hs
@@ -1,0 +1,6 @@
+module Database.Persist.Sql.Lifted.Expression.Projection
+  ( (^.)
+  , (?.)
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/String.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/String.hs
@@ -1,0 +1,18 @@
+module Database.Persist.Sql.Lifted.Expression.String
+  ( lower_
+  , upper_
+  , trim_
+  , ltrim_
+  , rtrim_
+  , length_
+  , left_
+  , right_
+  , like
+  , ilike
+  , (%)
+  , concat_
+  , (++.)
+  , castString
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/SubSelect.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/SubSelect.hs
@@ -1,0 +1,10 @@
+module Database.Persist.Sql.Lifted.Expression.SubSelect
+  ( subSelect
+  , subSelectMaybe
+  , subSelectCount
+  , subSelectForeign
+  , subSelectList
+  , subSelectUnsafe
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Table.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Table.hs
@@ -1,0 +1,6 @@
+module Database.Persist.Sql.Lifted.Expression.Table
+  ( getTable
+  , getTableMaybe
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Type.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Type.hs
@@ -1,0 +1,5 @@
+module Database.Persist.Sql.Lifted.Expression.Type
+  ( SqlExpr
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Update.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/Update.hs
@@ -1,0 +1,9 @@
+module Database.Persist.Sql.Lifted.Expression.Update
+  ( (=.)
+  , (+=.)
+  , (-=.)
+  , (*=.)
+  , (/=.)
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Filter.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Filter.hs
@@ -1,0 +1,23 @@
+module Database.Persist.Sql.Lifted.Filter
+  ( -- * Type
+    Filter
+
+    -- * Equality
+  , (==.)
+  , (!=.)
+
+    -- * Less & greater
+  , (<.)
+  , (>.)
+  , (<=.)
+  , (>=.)
+
+    -- * Lists
+  , (<-.)
+  , (/<-.)
+
+    -- * Disjunction
+  , (||.)
+  ) where
+
+import Database.Persist

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/From.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/From.hs
@@ -1,0 +1,22 @@
+module Database.Persist.Sql.Lifted.From
+  ( -- * Type
+    From
+
+    -- * Table
+  , from
+  , table
+
+    -- * Joins
+  , (:&) (..)
+  , on
+  , innerJoin
+  , innerJoinLateral
+  , leftJoin
+  , leftJoinLateral
+  , rightJoin
+  , fullOuterJoin
+  , crossJoin
+  , crossJoinLateral
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query.hs
@@ -1,0 +1,50 @@
+module Database.Persist.Sql.Lifted.Query
+  ( -- * Type
+    SqlQuery
+
+    -- * Where
+  , where_
+
+    -- * Aggregate
+  , groupBy
+  , groupBy_
+  , having
+
+    -- * Limit & offset
+  , limit
+  , offset
+
+    -- * Distinct & order by
+  , distinct
+  , distinctOn
+  , orderBy
+  , don
+  , distinctOnOrderBy
+
+    -- * Update
+  , set
+
+    -- * withNonNull
+  , withNonNull
+
+    -- * Locking
+  , locking
+  , LockingKind (..)
+
+    -- * Set operations
+  , union_
+  , unionAll_
+  , except_
+  , intersect_
+
+    -- * Common table expressions
+  , with
+  , withRecursive
+  ) where
+
+import Database.Persist.Sql.Lifted.Query.Aggregate
+import Database.Persist.Sql.Lifted.Query.CommonTableExpressions
+import Database.Persist.Sql.Lifted.Query.Core
+import Database.Persist.Sql.Lifted.Query.Locking
+import Database.Persist.Sql.Lifted.Query.SetOperations
+import Database.Persist.Sql.Lifted.Query.Update

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/Aggregate.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/Aggregate.hs
@@ -1,0 +1,7 @@
+module Database.Persist.Sql.Lifted.Query.Aggregate
+  ( groupBy
+  , groupBy_
+  , having
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/CommonTableExpressions.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/CommonTableExpressions.hs
@@ -1,0 +1,6 @@
+module Database.Persist.Sql.Lifted.Query.CommonTableExpressions
+  ( with
+  , withRecursive
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/Core.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/Core.hs
@@ -1,0 +1,23 @@
+module Database.Persist.Sql.Lifted.Query.Core
+  ( -- * Type
+    SqlQuery
+
+    -- * Where
+  , where_
+
+    -- * Limit & offset
+  , limit
+  , offset
+
+    -- * Distinct & order by
+  , distinct
+  , distinctOn
+  , orderBy
+  , don
+  , distinctOnOrderBy
+
+    -- * withNonNull
+  , withNonNull
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/Locking.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/Locking.hs
@@ -1,0 +1,6 @@
+module Database.Persist.Sql.Lifted.Query.Locking
+  ( locking
+  , LockingKind (..)
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/SetOperations.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/SetOperations.hs
@@ -1,0 +1,9 @@
+module Database.Persist.Sql.Lifted.Query.SetOperations
+  ( union_
+  , unionAll_
+  , except_
+  , intersect_
+  )
+where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/Update.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Query/Update.hs
@@ -1,0 +1,5 @@
+module Database.Persist.Sql.Lifted.Query.Update
+  ( set
+  ) where
+
+import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Update.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Update.hs
@@ -1,0 +1,15 @@
+module Database.Persist.Sql.Lifted.Update
+  ( -- * Type
+    Update
+
+    -- * Basic update
+  , (=.)
+
+    -- * Arithmetic update
+  , (+=.)
+  , (-=.)
+  , (*=.)
+  , (/=.)
+  ) where
+
+import Database.Persist

--- a/persistent-sql-lifted/package.yaml
+++ b/persistent-sql-lifted/package.yaml
@@ -1,5 +1,5 @@
 name: persistent-sql-lifted
-version: 0.1.1.0
+version: 0.2.0.0
 
 maintainer: Freckle Education
 category: Database

--- a/persistent-sql-lifted/persistent-sql-lifted.cabal
+++ b/persistent-sql-lifted/persistent-sql-lifted.cabal
@@ -37,10 +37,39 @@ library
       Database.Persist.Sql.Lifted
       Database.Persist.Sql.Lifted.Core
       Database.Persist.Sql.Lifted.Esqueleto
+      Database.Persist.Sql.Lifted.Expression
+      Database.Persist.Sql.Lifted.Expression.Bool
+      Database.Persist.Sql.Lifted.Expression.Case
+      Database.Persist.Sql.Lifted.Expression.Comparison
+      Database.Persist.Sql.Lifted.Expression.Constant
+      Database.Persist.Sql.Lifted.Expression.Count
+      Database.Persist.Sql.Lifted.Expression.Exists
+      Database.Persist.Sql.Lifted.Expression.Insert
+      Database.Persist.Sql.Lifted.Expression.Key
+      Database.Persist.Sql.Lifted.Expression.List
+      Database.Persist.Sql.Lifted.Expression.Maybe
+      Database.Persist.Sql.Lifted.Expression.Number
+      Database.Persist.Sql.Lifted.Expression.OrderBy
+      Database.Persist.Sql.Lifted.Expression.Projection
+      Database.Persist.Sql.Lifted.Expression.String
+      Database.Persist.Sql.Lifted.Expression.SubSelect
+      Database.Persist.Sql.Lifted.Expression.Table
+      Database.Persist.Sql.Lifted.Expression.Type
+      Database.Persist.Sql.Lifted.Expression.Update
+      Database.Persist.Sql.Lifted.Filter
+      Database.Persist.Sql.Lifted.From
       Database.Persist.Sql.Lifted.HasSqlBackend
       Database.Persist.Sql.Lifted.MonadSqlBackend
       Database.Persist.Sql.Lifted.MonadSqlTx
       Database.Persist.Sql.Lifted.Persistent
+      Database.Persist.Sql.Lifted.Query
+      Database.Persist.Sql.Lifted.Query.Aggregate
+      Database.Persist.Sql.Lifted.Query.CommonTableExpressions
+      Database.Persist.Sql.Lifted.Query.Core
+      Database.Persist.Sql.Lifted.Query.Locking
+      Database.Persist.Sql.Lifted.Query.SetOperations
+      Database.Persist.Sql.Lifted.Query.Update
+      Database.Persist.Sql.Lifted.Update
   other-modules:
       Paths_persistent_sql_lifted
   hs-source-dirs:


### PR DESCRIPTION
The aims here are two:

1. Esqueleto has one giant module that exports both

    - the query runners (`select`, `update`, etc.) that you don't want to import if you're using `persistent-sql-lifted` because they conflict with the lifted versions
    - the query and expression builders (`from`, `table`, `where`, a lot of infix ops, etc.) that you still do need

   so we want to isolate the things you do want so that you may import them without having to hide stuff.

2. Esqueleto's SQL expression utilities include a bunch of things that we often want to hide, e.g.

    - `isNothing` conflicts with base
    - `^.` and `set` conflict with lens
    - `==.` conflicts with persistent

   so this API provides smaller groupings of reexports, with the intent that application code (or applications' internal preludes) has the option to more easily cherry-pick what it needs. In case cherry-picking is not wanted, the `Expression` and `Query` modules further re-export everything under them.

This is not a breaking change, but I did a major bump just because it's a lot.