### PR TITLE
remove 'rand'

### DIFF
--- a/persistent-sql-lifted/CHANGELOG.md
+++ b/persistent-sql-lifted/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.2.0.0...main)
+## [_Unreleased_](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.3.0.0...main)
+
+## [v0.3.0.0](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.2.0.0...persistent-sql-lifted-v0.3.0.0)
+
+Remove `rand`; supports `esqueleto-3.6`.
 
 ## [v0.2.0.0](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.1.1.0...persistent-sql-lifted-v0.2.0.0)
 

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression.hs
@@ -76,7 +76,6 @@ module Database.Persist.Sql.Lifted.Expression
     -- * OrderBy
   , asc
   , desc
-  , rand
 
     -- * Projection
   , (^.)

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/OrderBy.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted/Expression/OrderBy.hs
@@ -1,7 +1,6 @@
 module Database.Persist.Sql.Lifted.Expression.OrderBy
   ( asc
   , desc
-  , rand
   ) where
 
 import Database.Esqueleto.Experimental

--- a/persistent-sql-lifted/package.yaml
+++ b/persistent-sql-lifted/package.yaml
@@ -1,5 +1,5 @@
 name: persistent-sql-lifted
-version: 0.2.0.0
+version: 0.3.0.0
 
 maintainer: Freckle Education
 category: Database

--- a/persistent-sql-lifted/persistent-sql-lifted.cabal
+++ b/persistent-sql-lifted/persistent-sql-lifted.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           persistent-sql-lifted
-version:        0.1.1.0
+version:        0.3.0.0
 synopsis:       Monad classes for running queries with Persistent and Esqueleto
 description:    This package introduces two classes: MonadSqlBackend for monadic contexts in
                 which a SqlBackend is available, and MonadSqlTx for contexts in which we


### PR DESCRIPTION
`rand` was deprecated, and its inclusion here was a mistake. Esqueleto 3.6, released just yesterday, removes it.