### PR TITLE
add more Persistent functions, remove one

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,2 +1,4 @@
 cradle:
   stack:
+    - path: "persistent-sql-lifted/library"
+      component: "persistent-sql-lifted:lib"

--- a/persistent-sql-lifted/CHANGELOG.md
+++ b/persistent-sql-lifted/CHANGELOG.md
@@ -1,4 +1,20 @@
-## [_Unreleased_](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.3.0.0...main)
+## [_Unreleased_](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.4.0.0...main)
+
+## [v0.4.0.0](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.3.0.0...persistent-sql-lifted-v0.4.0.0)
+
+Remove `selectKeys` because Persistent's Conduit-based utilities are of dubious correctness.
+
+Add:
+
+- `deleteWhereCount`
+- `existsBy`
+- `getFieldName`
+- `getTableName`
+- `insertUnique_`
+- `rawExecute`
+- `rawExecuteCount`
+- `rawSql`
+- `updateWhereCount`
 
 ## [v0.3.0.0](https://github.com/freckle/persistent-sql-lifted/compare/persistent-sql-lifted-v0.2.0.0...persistent-sql-lifted-v0.3.0.0)
 

--- a/persistent-sql-lifted/library/Database/Persist/Sql/Lifted.hs
+++ b/persistent-sql-lifted/library/Database/Persist/Sql/Lifted.hs
@@ -34,13 +34,13 @@ module Database.Persist.Sql.Lifted
   , select
   , selectOne
   , selectFirst
-  , selectKeys
   , selectKeysList
   , selectList
 
     -- * Selecting counts/existence
   , count
   , exists
+  , existsBy
 
     -- * Inserting
   , insertSelect
@@ -55,6 +55,7 @@ module Database.Persist.Sql.Lifted
   , insertMany_
   , insertRecord
   , insertUnique
+  , insertUnique_
   , insertUniqueEntity
 
     -- * Updating
@@ -63,6 +64,7 @@ module Database.Persist.Sql.Lifted
   , update'
   , updateGet
   , updateWhere
+  , updateWhereCount
 
     -- * Insert/update combinations
   , replace
@@ -84,12 +86,22 @@ module Database.Persist.Sql.Lifted
   , deleteBy
   , deleteWhere
   , deleteCount
+  , deleteWhereCount
 
     -- * Transactions
   , transactionSave
   , transactionSaveWithIsolation
   , transactionUndo
   , transactionUndoWithIsolation
+
+    -- * Raw SQL
+  , rawSql
+  , rawExecute
+  , rawExecuteCount
+
+    -- * Getting names
+  , getFieldName
+  , getTableName
 
     -- * Rendering queries to text
   , renderQueryDelete

--- a/persistent-sql-lifted/package.yaml
+++ b/persistent-sql-lifted/package.yaml
@@ -1,5 +1,5 @@
 name: persistent-sql-lifted
-version: 0.3.0.0
+version: 0.4.0.0
 
 maintainer: Freckle Education
 category: Database
@@ -59,7 +59,6 @@ library:
   source-dirs: library
   dependencies:
     - annotated-exception
-    - conduit
     - containers
     - esqueleto
     - mtl

--- a/persistent-sql-lifted/persistent-sql-lifted.cabal
+++ b/persistent-sql-lifted/persistent-sql-lifted.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           persistent-sql-lifted
-version:        0.3.0.0
+version:        0.4.0.0
 synopsis:       Monad classes for running queries with Persistent and Esqueleto
 description:    This package introduces two classes: MonadSqlBackend for monadic contexts in
                 which a SqlBackend is available, and MonadSqlTx for contexts in which we
@@ -84,7 +84,6 @@ library
   build-depends:
       annotated-exception
     , base <5
-    , conduit
     , containers
     , esqueleto
     , mtl

--- a/stack-lts20.yaml
+++ b/stack-lts20.yaml
@@ -4,4 +4,4 @@ packages:
   - persistent-sql-lifted
 
 extra-deps:
-  - persistent-2.14.0.1
+  - persistent-2.14.5.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+stack-lts23.yaml


### PR DESCRIPTION
- I had omitted `selectSource` intentionally because persistent's streaming doesn't really work (https://github.com/yesodweb/persistent/issues/657) but should have omitted `selectKeys` for the same reason, so this removes it now.
- There are nine functions that should have been included but were accidentally omitted; this adds them.